### PR TITLE
Check for existence of ssh config file

### DIFF
--- a/lib/poet.rb
+++ b/lib/poet.rb
@@ -32,7 +32,7 @@ class PoetCLI < Thor
       Process.exit!(3)
     end
     FileUtils.mkdir_p(options[:dir])
-    FileUtils.mv(file, options[:dir])
+    FileUtils.mv(file, options[:dir]) if File.file?(file)
     create
   end
 


### PR DESCRIPTION
If there is no ~/.ssh/config file then `poet bootstrap` spits out an error. Handle this case gracefully.
