### PR TITLE
Explicitly require digest/md5

### DIFF
--- a/lib/poet.rb
+++ b/lib/poet.rb
@@ -1,6 +1,7 @@
 require "poet/version"
 require "thor"
 require "fileutils"
+require "digest/md5"
 
 class PoetCLI < Thor
 


### PR DESCRIPTION
When using Ruby 2.0.0-p353, I was getting this error after editing a file using poet:

``` bash
 ~ $ poet edit private
/Users/mateusz/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/poet-0.8/lib/poet.rb:111:in `edit': uninitialized constant PoetCLI::Digest (NameError)
    from /Users/mateusz/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/thor-0.18.1/lib/thor/command.rb:27:in `run'
    from /Users/mateusz/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/thor-0.18.1/lib/thor/invocation.rb:120:in `invoke_command'
    from /Users/mateusz/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/thor-0.18.1/lib/thor.rb:363:in `dispatch'
    from /Users/mateusz/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/thor-0.18.1/lib/thor/base.rb:439:in `start'
    from /Users/mateusz/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/poet-0.8/bin/poet:5:in `<top (required)>'
    from /Users/mateusz/.rbenv/versions/2.0.0-p353/bin/poet:23:in `load'
    from /Users/mateusz/.rbenv/versions/2.0.0-p353/bin/poet:23:in `<main>'
```

Including the `Digest::MD5` module explicitly did fix it. The problem is I could not reproduce this behavior in the test suite, probably because of the module being required by some other gems by coincidence.
