### PR TITLE
Drop support for Ruby 1.9, officially support Ruby 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 
 language: ruby
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.0
   - 2.2.0

--- a/History.txt
+++ b/History.txt
@@ -1,5 +1,7 @@
 master
 
+- drop support for Ruby 1.9, officially support Ruby 2.2
+
 0.8.1
 
 - fixed bug "uninitialized constant PoetCLI::Digest" on 2.0 (thanks @yagooar)

--- a/poet.gemspec
+++ b/poet.gemspec
@@ -23,5 +23,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "cucumber"
   s.add_development_dependency "aruba"
   s.add_development_dependency "rake"
+  s.required_ruby_version = '>= 2.0.0'
   s.add_runtime_dependency "thor"
 end


### PR DESCRIPTION
I'd like to open this for discussion since support for Ruby 1.9.3 has [ended over a year ago](https://www.ruby-lang.org/en/news/2015/02/23/support-for-ruby-1-9-3-has-ended/)…